### PR TITLE
Add "tshark" requirement and "pcap" format to doc

### DIFF
--- a/README
+++ b/README
@@ -29,3 +29,6 @@ Alternatively you can open the .pro file in QtCreator and build from
 there.
 
 
+Running
+========
+WireDiff reads standard PCAP files. It requires "tshark" on the path.


### PR DESCRIPTION
When opening the first traces, nothing happend... except 
`load trace failed` :-(

Thanks to https://github.com/aaptel/qtwirediff/issues/1 I installed `tshark` and now it works. This requirement should be documented, here's the corresponding PR.