### PR TITLE
Add compatibility to Qt6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: install deps
-      run: sudo apt-get install build-essential qt5-default tshark 
+      run: sudo apt-get install build-essential qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools tshark
     - name: qmake
       run: qmake
     - name: make

--- a/sessionitem.cpp
+++ b/sessionitem.cpp
@@ -2,7 +2,7 @@
 #include <QFileInfo>
 
 
-SessionItem::SessionItem(QWidget* p, Session* ses) : QAction(p), ses_(*ses)
+SessionItem::SessionItem(QObject* p, Session* ses) : QAction(p), ses_(*ses)
 {
      setText(QFileInfo(ses_.fileA).fileName()+" | "+QFileInfo(ses_.fileB).fileName());
 }

--- a/sessionitem.h
+++ b/sessionitem.h
@@ -8,7 +8,7 @@ class SessionItem : public QAction
     Q_OBJECT
     public:
     Session ses_;
-    SessionItem(QWidget* p=0, Session* ses=0);
+    SessionItem(QObject* p=0, Session* ses=0);
 };
 
 #endif // SESSIONITEM_H

--- a/trace.cpp
+++ b/trace.cpp
@@ -34,50 +34,50 @@ int Trace::loadTrace(const QString &fn, const QString &filter)
 
     if (!xml.readNextStartElement())
         return -1;
-    if (xml.name() != "psml")
+    if (xml.name() != QString("psml"))
         return -1;
     if (!xml.readNextStartElement())
         return -1;
-    if (xml.name() != "structure")
+    if (xml.name() != QString("structure"))
         return -1;
 
-    if (!(xml.readNextStartElement() && xml.name() == "section" && xml.readNext() && xml.text() == "No.")) {
+    if (!(xml.readNextStartElement() && xml.name() == QString("section") && xml.readNext() && xml.text() == QString("No."))) {
 	qDebug("bad section, expected no");
 	return -1;
     }
     xml.skipCurrentElement();
 
-    if (!(xml.readNextStartElement() && xml.name() == "section" && xml.readNext() && xml.text() == "Time")) {
+    if (!(xml.readNextStartElement() && xml.name() == QString("section") && xml.readNext() && xml.text() == QString("Time"))) {
 	qDebug("bad section, expected time");
 	return -1;
     }
     xml.skipCurrentElement();
 
-    if (!(xml.readNextStartElement() && xml.name() == "section" && xml.readNext() && xml.text() == "Source")) {
+    if (!(xml.readNextStartElement() && xml.name() == QString("section") && xml.readNext() && xml.text() == QString("Source"))) {
 	qDebug("bad section, expected source");
 	return -1;
     }
     xml.skipCurrentElement();
 
-    if (!(xml.readNextStartElement() && xml.name() == "section" && xml.readNext() && xml.text() == "Destination")) {
+    if (!(xml.readNextStartElement() && xml.name() == QString("section") && xml.readNext() && xml.text() == QString("Destination"))) {
 	qDebug("bad section, expected destination");
 	return -1;
     }
     xml.skipCurrentElement();
 
-    if (!(xml.readNextStartElement() && xml.name() == "section" && xml.readNext() && xml.text() == "Protocol")) {
+    if (!(xml.readNextStartElement() && xml.name() == QString("section") && xml.readNext() && xml.text() == QString("Protocol"))) {
 	qDebug("bad section, expected protocol");
 	return -1;
     }
     xml.skipCurrentElement();
 
-    if (!(xml.readNextStartElement() && xml.name() == "section" && xml.readNext() && xml.text() == "Length")) {
+    if (!(xml.readNextStartElement() && xml.name() == QString("section") && xml.readNext() && xml.text() == QString("Length"))) {
 	qDebug("bad section, expected length");
 	return -1;
     }
     xml.skipCurrentElement();
 
-    if (!(xml.readNextStartElement() && xml.name() == "section" && xml.readNext() && xml.text() == "Info")) {
+    if (!(xml.readNextStartElement() && xml.name() == QString("section") && xml.readNext() && xml.text() == QString("Info"))) {
 	qDebug("bad section, expected info");
 	return -1;
     }
@@ -92,48 +92,48 @@ int Trace::loadTrace(const QString &fn, const QString &filter)
     }
     int i = 0;
     do {
-        if (xml.name() != "packet")
+        if (xml.name() != QString("packet"))
             return -1;
         pkts_.append(Summary());
 
-        if (!xml.readNextStartElement() || xml.name() != "section")
+        if (!xml.readNextStartElement() || xml.name() != QString("section"))
             return -1;
         xml.readNext();
         pkts_[i].no = xml.text().toInt();
         xml.skipCurrentElement();
 
-        if (!xml.readNextStartElement() || xml.name() != "section")
+        if (!xml.readNextStartElement() || xml.name() != QString("section"))
             return -1;
         xml.readNext();
         pkts_[i].time = xml.text().toDouble();
         xml.skipCurrentElement();
 
-        if (!xml.readNextStartElement() || xml.name() != "section")
+        if (!xml.readNextStartElement() || xml.name() != QString("section"))
             return -1;
         xml.readNext();
         pkts_[i].src = xml.text().toString();
         xml.skipCurrentElement();
 
-        if (!xml.readNextStartElement() || xml.name() != "section")
+        if (!xml.readNextStartElement() || xml.name() != QString("section"))
             return -1;
         xml.readNext();
         pkts_[i].dst = xml.text().toString();
         xml.skipCurrentElement();
 
-        if (!xml.readNextStartElement() || xml.name() != "section")
+        if (!xml.readNextStartElement() || xml.name() != QString("section"))
             return -1;
         xml.readNext();
         pkts_[i].proto = xml.text().toString();
         xml.skipCurrentElement();
 
-        if (!xml.readNextStartElement() || xml.name() != "section")
+        if (!xml.readNextStartElement() || xml.name() != QString("section"))
             return -1;
         xml.readNext();
         // we don't care about length
         //pkts_[i].src = xml.text();
         xml.skipCurrentElement();
 
-        if (!xml.readNextStartElement() || xml.name() != "section")
+        if (!xml.readNextStartElement() || xml.name() != QString("section"))
             return -1;
         xml.readNext();
         pkts_[i].info = xml.text().toString();
@@ -229,12 +229,12 @@ static Trace::Node* parseNode(QXmlStreamReader& xml)
         throw Trace::ParseError();
     }
 
-    if (xml.name() == "packet") {
+    if (xml.name() == QString("packet")) {
         n->name = "root";
         n->val = "";
         n->parent = nullptr;
     } else {
-        if (xml.name() != "proto" && xml.name() != "field") {
+        if (xml.name() != QString("proto") && xml.name() != QString("field")) {
             qDebug("not at <proto> or <field>");
             throw Trace::ParseError();
         }
@@ -264,11 +264,11 @@ Trace::Node* Trace::getPacket(int no)
 
         if (!xml.readNextStartElement())
             throw ParseError();
-        if (xml.name() != "pdml")
+        if (xml.name() != QString("pdml"))
             throw ParseError();
         if (!xml.readNextStartElement())
             throw ParseError();
-        if (xml.name() != "packet")
+        if (xml.name() != QString("packet"))
             throw ParseError();
 
         cache_.insert(no, new Trace::Tree(parseNode(xml)));

--- a/trace.h
+++ b/trace.h
@@ -33,7 +33,7 @@ public:
         static void releaseNodeHierarchy(Node *);
     };
 
-    class ParseError : public QtConcurrent::Exception
+    class ParseError : public QException
     {
     public:
         void raise() const { throw *this; }


### PR DESCRIPTION
This adds compatibility to Qt6 and still maintains compatibilty to Qt5. Wireshark 4 switched to Qt6 on most platforms, therefore qtwirediff should be compileable with Qt6 because it will be stored in the Wireshark directory and use its Qt6 libraries.