### PR TITLE
Add compatibility for windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: install deps
-      run: sudo apt-get install build-essential qt5-default tshark 
+      run: sudo apt-get install build-essential qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools tshark
     - name: qmake
       run: qmake
     - name: make

--- a/trace.cpp
+++ b/trace.cpp
@@ -12,14 +12,21 @@ int Trace::loadTrace(const QString &fn, const QString &filter)
     filter_ = filter;
 
     QProcess proc;
+    QString tshark;
     QStringList args;
+
+    #if (defined(Q_OS_WINDOWS))
+        tshark = "tshark.exe";
+    #else
+        tshark = "tshark";
+    #endif
 
     args << "-r" << fn_;
     if (!filter_.isEmpty())
         args << "-Y" << filter;
     args << "-T" << "psml";
 
-    proc.start("tshark", args, QProcess::ReadOnly);
+    proc.start(tshark, args, QProcess::ReadOnly);
     proc.waitForStarted();
     proc.waitForFinished();
 
@@ -159,13 +166,20 @@ void Trace::dump()
 QByteArray* Trace::getPDML(int no)
 {
     QProcess proc;
+    QString tshark;
     QStringList args;
+
+    #if (defined(Q_OS_WINDOWS))
+        tshark = "tshark.exe";
+    #else
+        tshark = "tshark";
+    #endif
 
     args << "-r" << fn_;
     args << "-Y" << (QString("frame.number == %1").arg(no));
     args << "-T" << "pdml";
 
-    proc.start("tshark", args, QProcess::ReadOnly);
+    proc.start(tshark, args, QProcess::ReadOnly);
     proc.waitForStarted();
     proc.waitForFinished();
 


### PR DESCRIPTION
This adds compatibility for the Windows operating system by calling tshark with its filename extension.
As requested in #5 I provide a prebuilt executable in my fork. Feel free to add this to your releases.